### PR TITLE
tiny_mce_gzip.php: cache shouldn't be shared between multiple PHP projects using TinyMCE

### DIFF
--- a/tiny_mce_gzip.php
+++ b/tiny_mce_gzip.php
@@ -159,7 +159,7 @@ class TinyMCE_Compressor {
 		}
 
 		// Generate hash for all files
-		$hash = md5(implode('', $allFiles));
+		$hash = md5(implode('', $allFiles) . $_SERVER['SCRIPT_NAME']);
 
 		// Check if it supports gzip
 		$zlibOn = ini_get('zlib.output_compression') || (ini_set('zlib.output_compression', 0) === false);


### PR DESCRIPTION
Add `$_SERVER['SCRIPT_NAME']` into the `md5()` call so that the cache isn't shared between multiple PHP projects using the same TinyMCE codebase.

We've made this as a local modification to the SilverStripe Framework here: https://github.com/silverstripe/sapphire/commit/8de7b745fc6b62e6112b6f8d47a985e459ce971c
and it seemed like a general purpose fix, so proposing this pull request here. :-)

Thanks,
Sean
