### PR TITLE
Update tiny_mce_gzip.php

### DIFF
--- a/tiny_mce_gzip.php
+++ b/tiny_mce_gzip.php
@@ -191,7 +191,7 @@ class TinyMCE_Compressor {
 		}
 
 		// Set base URL for where tinymce is loaded from
-		$buffer = "var tinyMCEPreInit={base:'" . dirname($_SERVER["SCRIPT_NAME"]) . "',suffix:''};";
+		$buffer = "var tinyMCEPreInit={base:'" . dirname($_SERVER['SERVER_NAME'] . $_SERVER["SCRIPT_NAME"]) . "',suffix:''};";
 
 		// Load all tinymce script files into buffer
 		foreach ($allFiles as $file) {

--- a/tiny_mce_gzip.php
+++ b/tiny_mce_gzip.php
@@ -191,8 +191,14 @@ class TinyMCE_Compressor {
 		}
 
 		// Set base URL for where tinymce is loaded from
-		$buffer = "var tinyMCEPreInit={base:'" . dirname($_SERVER['SERVER_NAME'] . $_SERVER["SCRIPT_NAME"]) . "',suffix:''};";
-
+		$buffer = "";
+		if ($_SERVER['HTTP_X_FORWARDED_HOST']){
+			$buffer = "var tinyMCEPreInit={base:'" . dirname($_SERVER['SERVER_NAME'] . $_SERVER["SCRIPT_NAME"]) . "',suffix:''};";
+		}
+		else {
+			$buffer = "var tinyMCEPreInit={base:'" . dirname( $_SERVER['SCRIPT_NAME']) . "',suffix:''};";
+		}
+		
 		// Load all tinymce script files into buffer
 		foreach ($allFiles as $file) {
 			if ($file) {


### PR DESCRIPTION
I use contao CMS and TinyMCE in a SSL-Proxy environment. It makes my server accessible with SSL but sets the SSl-Proxy URL in front of the original server name. In this case TinyMCE will be loaded with wrong path and I can't use TinyMCE in SSL-Proxy environment. With the patch above it works. (see also https://github.com/contao/core/issues/3616#issuecomment-7636126)
