### PR TITLE
Fixed loading .min.js files

### DIFF
--- a/tinymce.gzip.js
+++ b/tinymce.gzip.js
@@ -30,7 +30,7 @@
 		// Seems that onreadystatechange works better on IE 10 onload seems to fire incorrectly
 		if ("onreadystatechange" in elm) {
 			elm.onreadystatechange = function() {
-				if (elm.readyState == "loaded") {
+				if (elm.readyState == "loaded" || elm.readyState == "complete") {
 					done();
 				}
 			};

--- a/tinymce.gzip.php
+++ b/tinymce.gzip.php
@@ -169,8 +169,10 @@ class TinyMCE_Compressor {
 
 			if ($this->settings["source"] && file_exists($file . ".js")) {
 				$file .= ".js";
-			} else if (file_exists($file . ".js"))  {
+			} else if (file_exists($file . ".min.js"))  {
 				$file .= ".min.js";
+			} else if (file_exists($file . ".js"))  {
+				$file .= ".js";
 			} else {
 				$file = "";
 			}


### PR DESCRIPTION
Test for existence .js file and loading .min.js file is bug or nonsence. So I fixed it and added fallback for .js files loading, if .min.js file is missing and we want minified version.
