### PR TITLE
Fixed loading script from browser cache in IE

### DIFF
--- a/tinymce.gzip.js
+++ b/tinymce.gzip.js
@@ -30,7 +30,7 @@
 		// Seems that onreadystatechange works better on IE 10 onload seems to fire incorrectly
 		if ("onreadystatechange" in elm) {
 			elm.onreadystatechange = function() {
-				if (elm.readyState == "loaded") {
+				if (elm.readyState == "loaded" || elm.readyState == "complete") {
 					done();
 				}
 			};


### PR DESCRIPTION
When gziped file is loaded from browser cache (http code 304), readyState is not loaded, but compete.
Without this fix, TinyMCE is not loaded in IE, when gzipped file is cached in browser cache.
